### PR TITLE
Xml2Json Firefox fix

### DIFF
--- a/externals/xml2json.js
+++ b/externals/xml2json.js
@@ -534,19 +534,9 @@ function X2JS(config) {
         var xmlDoc;
         if (window.DOMParser) {
             var parser=new window.DOMParser();
-            var parsererrorNS = null;
-            // IE9+ now is here
-            if(!isIEParser) {
-                try {
-                    parsererrorNS = parser.parseFromString("INVALID", "text/xml").getElementsByTagName("parsererror")[0].namespaceURI;
-                }
-                catch(err) {
-                    parsererrorNS = null;
-                }
-            }
             try {
                 xmlDoc = parser.parseFromString( xmlDocStr, "text/xml" );
-                if( parsererrorNS!= null && xmlDoc.getElementsByTagNameNS(parsererrorNS, "parsererror").length > 0) {
+                if(xmlDoc.getElementsByTagNameNS("*", "parseerror").length > 0) {
                     //throw new Error('Error parsing XML: '+xmlDocStr);
                     xmlDoc = null;
                 }


### PR DESCRIPTION
Patch to resolve an XML parse error: syntax error in Firefox for MPD files

https://github.com/dkdndes/x2js/issues/32